### PR TITLE
Consolidate MarkerBundle into Marker

### DIFF
--- a/examples/custom-icons-with-markers/src/main.rs
+++ b/examples/custom-icons-with-markers/src/main.rs
@@ -56,7 +56,7 @@ fn use_map(geojson: GeoJson) -> Rc<RefCell<Option<MapFactory>>> {
                         let point = feature["geometry"]["coordinates"].as_array().unwrap();
                         let lnglat =
                             LngLat::new(point[0].as_f64().unwrap(), point[1].as_f64().unwrap());
-                        let marker = Marker::new(lnglat, marker_options);
+                        let marker = Marker::with_options(lnglat, marker_options);
                         marker.add_to(&m.map);
                     }
                 }

--- a/examples/draggable-marker/src/main.rs
+++ b/examples/draggable-marker/src/main.rs
@@ -1,8 +1,8 @@
 use futures::channel::oneshot;
 use log::info;
-use mapboxgl::marker::{MarkerBundle, MarkerEventListener};
 use mapboxgl::{
-    event, LngLat, Map, MapEventListener, MapFactory, MapOptions, Marker, MarkerOptions,
+    event, LngLat, Map, MapEventListener, MapFactory, MapOptions, Marker, MarkerEventListener,
+    MarkerOptions,
 };
 use std::{cell::RefCell, rc::Rc};
 use web_sys::{Document, Element};
@@ -52,10 +52,9 @@ fn use_map() -> Rc<RefCell<Option<MapFactory>>> {
                 // add marker
                 let mut marker_options = MarkerOptions::new();
                 marker_options.draggable = Some(true);
-                let marker = Marker::new(LngLat::new(0.0, 0.0), marker_options);
-                let mut mb = MarkerBundle::new(marker.into());
-                mb.set_listener(MarkerListener {});
-                let _id = m.add_marker(mb);
+                let marker =
+                    Marker::with_listener(LngLat::new(0.0, 0.0), marker_options, MarkerListener {});
+                m.add_marker(marker);
 
                 wasm_bindgen_futures::spawn_local(async move {
                     rx.await.unwrap();


### PR DESCRIPTION
As discussed with @shimatar0 in the thread below,
https://github.com/yukinarit/mapbox-gl-rs/pull/45

I never liked the naming XXXFactory, because it's doing more than creating objects. This is my attempt to consolidate XXXBundle and XXXFactory into Marker. I used RefCell to make handle mutable.

I still wanted to make Listener optional for Marker. So, I added three factory methods to create Marker
* new: create a marker with the coordinate
* with_options: create a marker with the coordinate and options
* with_listener: create a marker with the coordinate, options and event listener